### PR TITLE
Fix README and transitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This project generates slideshow videos from user-provided images and text, with
 ## 🛠️ Tech Stack
 
 - **Frontend:** React, Axios
-- **Backend:** Python, Flask (or FastAPI)
+- **Backend:** Python, Django REST Framework
 - **Video Engine:** MoviePy
 
 ---
@@ -31,4 +31,8 @@ cd backend
 python3 -m venv venv
 source venv/bin/activate  # On Windows: venv\Scripts\activate
 pip install -r requirements.txt
-python app.py
+python manage.py migrate
+python manage.py runserver
+```
+
+Set the `IMAGEMAGICK_BINARY` environment variable if ImageMagick isn't in your `PATH`.

--- a/backend/api/video_generator.py
+++ b/backend/api/video_generator.py
@@ -8,11 +8,81 @@ from moviepy.video.fx.colorx import colorx
 from moviepy.audio.fx.audio_loop import audio_loop
 from moviepy.config import change_settings
 
-change_settings({
-    "IMAGEMAGICK_BINARY": r"C:\Program Files\ImageMagick-7.1.1-Q16-HDRI\magick.exe"
-})
+# Allow overriding the ImageMagick binary location via environment variable
+im_path = os.getenv("IMAGEMAGICK_BINARY")
+if im_path:
+    change_settings({"IMAGEMAGICK_BINARY": im_path})
 
-def apply_image_transition(clip1, clip2, duration=1):
+TRANSITION_DURATION = 0.3  # seconds for crossfades and text fades
+
+TEXT_TRANSITIONS = [
+    "fade",
+    "slide_left",
+    "slide_right",
+    "slide_top",
+    "slide_bottom",
+    "zoom",
+]
+
+def apply_text_transition(clip, transition, duration, final_pos, video_size):
+    """Apply one of several animation effects to a text clip."""
+    if transition == "fade":
+        return clip.set_position(final_pos).fx(fadein, duration).fx(fadeout, duration)
+
+    if transition.startswith("slide_"):
+        side = transition.split("_")[1]
+        vw, vh = video_size
+        x_final, y_final = final_pos if isinstance(final_pos, tuple) else ("center", "center")
+        if x_final == "center":
+            x_final = (vw - clip.w) // 2
+        if y_final == "center":
+            y_final = (vh - clip.h) // 2
+
+        start_map = {
+            "left": (-clip.w, y_final),
+            "right": (vw, y_final),
+            "top": (x_final, -clip.h),
+            "bottom": (x_final, vh),
+        }
+        start_pos = start_map.get(side, (x_final, y_final))
+        end_map = {
+            "left": (-clip.w, y_final),
+            "right": (vw, y_final),
+            "top": (x_final, -clip.h),
+            "bottom": (x_final, vh),
+        }
+        end_pos = end_map.get(side, (x_final, y_final))
+
+        def pos(t):
+            if t < duration:
+                p = t / duration
+                x = start_pos[0] + (x_final - start_pos[0]) * p
+                y = start_pos[1] + (y_final - start_pos[1]) * p
+                return x, y
+            elif t > clip.duration - duration:
+                p = (t - (clip.duration - duration)) / duration
+                x = x_final + (end_pos[0] - x_final) * p
+                y = y_final + (end_pos[1] - y_final) * p
+                return x, y
+            else:
+                return x_final, y_final
+
+        return clip.set_position(pos)
+
+    if transition == "zoom":
+        def resize(t):
+            if t < duration:
+                return 0.3 + 0.7 * (t / duration)
+            if t > clip.duration - duration:
+                return 0.3 + 0.7 * (max(clip.duration - t, 0) / duration)
+            return 1.0
+
+        return clip.set_position(final_pos).resize(resize)
+
+    # Fallback
+    return clip.set_position(final_pos)
+
+def apply_image_transition(clip1, clip2, duration=TRANSITION_DURATION):
     return concatenate_videoclips([
         clip1.crossfadeout(duration),
         clip2.crossfadein(duration)
@@ -28,6 +98,8 @@ def generate_video(texts, image_paths, music_path, output_path, duration_per_sli
     print(f"Number of image paths: {len(image_paths)}")
     print(f"Positions received: {positions}")
     print(f"🌓 Darkening level applied to images: {darkening}\n")
+    available_transitions = TEXT_TRANSITIONS.copy()
+    random.shuffle(available_transitions)
 
     for i, text in enumerate(texts):
         image_path = image_paths[i % len(image_paths)]
@@ -43,16 +115,28 @@ def generate_video(texts, image_paths, music_path, output_path, duration_per_sli
         except Exception as e:
             print(f"Invalid position: {e}")
             text_position = 'center'
-        try: 
-            txt_clip = TextClip(
-                text,
-                fontsize=40,
-                color='white',
-                font="Arial",  # or your font path
-                method='caption',
-                size=(size[0] - 100, None),
-                align='center'
-            ).set_duration(slide_duration).set_position(text_position)
+        try:
+            transition_name = available_transitions.pop() if available_transitions else random.choice(TEXT_TRANSITIONS)
+            txt_clip = (
+                TextClip(
+                    text,
+                    fontsize=40,
+                    color='white',
+                    font="Arial",  # or your font path
+                    method='caption',
+                    size=(size[0] - 100, None),
+                    align='center'
+                )
+                .set_duration(slide_duration)
+            )
+            txt_clip = apply_text_transition(
+                txt_clip,
+                transition_name,
+                TRANSITION_DURATION,
+                text_position,
+                size,
+            )
+            print(f"💫 Slide {i}: Text transition '{transition_name}' applied.")
         except Exception as e:
             print(f"❗ Slide {i}: TextClip creation failed. Error: {e}")
             continue  # Skip this slide if text rendering fails
@@ -84,7 +168,7 @@ def generate_video(texts, image_paths, music_path, output_path, duration_per_sli
 
     final_video = slides[0]
     for i in range(1, len(slides)):
-        final_video = apply_image_transition(final_video, slides[i], duration=0.3)
+        final_video = apply_image_transition(final_video, slides[i], duration=TRANSITION_DURATION)
 
     if music_path:
         try:

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -57,8 +57,10 @@ def create_slideshow(request):
             music_path = os.path.join(settings.MEDIA_ROOT, default_storage.save(f"media/{music.name}", ContentFile(music.read())))
             print(f"🎶 Music saved: {music_path}")
 
-        output_path = os.path.join(settings.MEDIA_ROOT, "final_video.mp4")
-        print("⚙️ Calling generate_video function...")
+        import uuid
+        unique_name = f"{uuid.uuid4().hex}.mp4"
+        output_path = os.path.join(settings.MEDIA_ROOT, unique_name)
+        print(f"⚙️ Calling generate_video function... output: {output_path}")
         generate_video(texts, image_paths, music_path, output_path, positions=positions, durations=durations, darkening=darkening)
 
         if not os.path.exists(output_path):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+Django>=5.2
+djangorestframework
+moviepy
+pillow
+django-cors-headers


### PR DESCRIPTION
## Summary
- fix README formatting and describe Django backend
- make ImageMagick path configurable via `IMAGEMAGICK_BINARY`
- implement custom slide transitions for text and randomize them
- generate unique output filenames
- add initial requirements list

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68451b995ca483249eeec5609f065422