### PR TITLE
Adjust text timing around image fades

### DIFF
--- a/backend/api/video_generator.py
+++ b/backend/api/video_generator.py
@@ -161,6 +161,7 @@ def generate_video(texts, image_paths, music_path, output_path, duration_per_sli
             text_position = 'center'
         try:
             transition_name = available_transitions.pop() if available_transitions else random.choice(TEXT_TRANSITIONS)
+            txt_duration = max(slide_duration - 2 * TRANSITION_DURATION, 0.1)
             txt_clip = (
                 TextClip(
                     text,
@@ -171,7 +172,7 @@ def generate_video(texts, image_paths, music_path, output_path, duration_per_sli
                     size=(size[0] - 100, None),
                     align='center'
                 )
-                .set_duration(slide_duration)
+                .set_duration(txt_duration)
             )
             txt_clip = apply_text_transition(
                 txt_clip,
@@ -221,8 +222,10 @@ def generate_video(texts, image_paths, music_path, output_path, duration_per_sli
     for dur in slide_durations[:-1]:
         start_times.append(start_times[-1] + dur - TRANSITION_DURATION)
 
+    text_start_times = [s + TRANSITION_DURATION for s in start_times]
+
     # Overlay text clips at their corresponding start times
-    overlays = [final_video] + [t.set_start(s) for t, s in zip(text_clips, start_times)]
+    overlays = [final_video] + [t.set_start(s) for t, s in zip(text_clips, text_start_times)]
     final_video = CompositeVideoClip(overlays, size=size)
 
     if music_path:


### PR DESCRIPTION
## Summary
- ensure text overlays disappear before images fade
- offset text start times to after image transitions

## Testing
- `python -m py_compile backend/api/video_generator.py`


------
https://chatgpt.com/codex/tasks/task_e_68463174bbd483249f597f61652135cd