### PR TITLE
Handle last slide text and allow transition selection

### DIFF
--- a/backend/api/video_generator.py
+++ b/backend/api/video_generator.py
@@ -130,9 +130,22 @@ def apply_image_transition(clip1, clip2, duration=TRANSITION_DURATION):
         method="compose",
     )
 
-def generate_video(texts, image_paths, music_path, output_path, duration_per_slide=4, size=(720, 1280), positions=None, durations=None, darkening=None):
+def generate_video(
+    texts,
+    image_paths,
+    music_path,
+    output_path,
+    duration_per_slide=4,
+    size=(720, 1280),
+    positions=None,
+    durations=None,
+    darkening=None,
+    transitions=None,
+):
     if positions is None:
         positions = []
+    if transitions is None:
+        transitions = []
     image_clips = []
     text_clips = []
     slide_durations = []
@@ -160,7 +173,19 @@ def generate_video(texts, image_paths, music_path, output_path, duration_per_sli
             print(f"Invalid position: {e}")
             text_position = 'center'
         try:
-            transition_name = available_transitions.pop() if available_transitions else random.choice(TEXT_TRANSITIONS)
+            if transitions and i < len(transitions) and transitions[i].strip():
+                transition_name = transitions[i].strip()
+            else:
+                transition_name = (
+                    available_transitions.pop()
+                    if available_transitions
+                    else random.choice(TEXT_TRANSITIONS)
+                )
+            is_last_slide = i == len(texts) - 1
+            if is_last_slide:
+                txt_duration = slide_duration
+            else:
+                txt_duration = max(slide_duration - 2 * TRANSITION_DURATION, 0.1)
             txt_clip = (
                 TextClip(
                     text,
@@ -171,7 +196,7 @@ def generate_video(texts, image_paths, music_path, output_path, duration_per_sli
                     size=(size[0] - 100, None),
                     align='center'
                 )
-                .set_duration(slide_duration)
+                .set_duration(txt_duration)
             )
             txt_clip = apply_text_transition(
                 txt_clip,
@@ -221,8 +246,10 @@ def generate_video(texts, image_paths, music_path, output_path, duration_per_sli
     for dur in slide_durations[:-1]:
         start_times.append(start_times[-1] + dur - TRANSITION_DURATION)
 
+    text_start_times = [s + TRANSITION_DURATION for s in start_times]
+
     # Overlay text clips at their corresponding start times
-    overlays = [final_video] + [t.set_start(s) for t, s in zip(text_clips, start_times)]
+    overlays = [final_video] + [t.set_start(s) for t, s in zip(text_clips, text_start_times)]
     final_video = CompositeVideoClip(overlays, size=size)
 
     if music_path:

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -16,6 +16,7 @@ def create_slideshow(request):
         positions = request.data.getlist('positions')  # Same length as texts
         durations = request.data.getlist('duration')
         durations = [float(d) if d else 4.0 for d in durations]
+        transitions = request.data.getlist('transitions')
         images = request.FILES.getlist('images')
         raw_darkening = request.data.getlist('darkening')
         print(f"📝 darkening received: {raw_darkening}")
@@ -61,7 +62,16 @@ def create_slideshow(request):
         unique_name = f"{uuid.uuid4().hex}.mp4"
         output_path = os.path.join(settings.MEDIA_ROOT, unique_name)
         print(f"⚙️ Calling generate_video function... output: {output_path}")
-        generate_video(texts, image_paths, music_path, output_path, positions=positions, durations=durations, darkening=darkening)
+        generate_video(
+            texts,
+            image_paths,
+            music_path,
+            output_path,
+            positions=positions,
+            durations=durations,
+            darkening=darkening,
+            transitions=transitions,
+        )
 
         if not os.path.exists(output_path):
             print("❌ Video file was not created!")

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -2,12 +2,26 @@ import React, { useState } from 'react';
 import axios from 'axios';
 import './App.css';
 
+const transitionOptions = [
+  'fade',
+  'slide_left',
+  'slide_right',
+  'slide_top',
+  'slide_bottom',
+  'zoom',
+  'typewriter',
+  'glitch',
+  'rotate',
+];
+
 function App() {
   const [images, setImages] = useState([]);
   const [music, setMusic] = useState(null);
   const [duration, setDuration] = useState(4);
   const [loading, setLoading] = useState(false);
-  const [slides, setSlides] = useState([{ text: '', position: '', darkening: '', duration: '' }]);
+  const [slides, setSlides] = useState([
+    { text: '', position: '', darkening: '', duration: '', transition: '' },
+  ]);
 
   const handleSlideChange = (index, field, value) => {
     const updated = [...slides];
@@ -25,6 +39,7 @@ function App() {
       formData.append('positions', slide.position);
       formData.append('darkening', slide.darkening);
       formData.append('duration', slide.duration); // May be blank
+      formData.append('transitions', slide.transition);
     });
     images.forEach(img => formData.append('images', img));
     if (music) formData.append('music', music);
@@ -89,9 +104,28 @@ function App() {
                 value={slide.duration}
                 onChange={(e) => handleSlideChange(i, 'duration', e.target.value)}
               />
+              <select
+                value={slide.transition}
+                onChange={(e) => handleSlideChange(i, 'transition', e.target.value)}
+              >
+                <option value="">Random</option>
+                {transitionOptions.map((opt) => (
+                  <option key={opt} value={opt}>
+                    {opt}
+                  </option>
+                ))}
+              </select>
             </div>
           ))}
-          <button type="button" onClick={() => setSlides([...slides, { text: '', position: '', darkening: '', duration: '' }])}>
+          <button
+            type="button"
+            onClick={() =>
+              setSlides([
+                ...slides,
+                { text: '', position: '', darkening: '', duration: '', transition: '' },
+              ])
+            }
+          >
             ➕ Add Another Slide
           </button>
         </div>


### PR DESCRIPTION
## Summary
- keep text on final slide until video ends
- let API receive `transitions` from the frontend
- expose transition dropdowns per slide in the React UI

## Testing
- `python -m py_compile backend/api/video_generator.py`
- `python -m py_compile backend/api/views.py`
- `npm test --prefix frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68463174bbd483249f597f61652135cd