### PR TITLE
Add image effects

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,24 @@ This project generates slideshow videos from user-provided images and text, with
 - Add custom text for each slide
 - Upload background music (optional)
 - Auto-generate a downloadable slideshow video
+- Apply visual effects to images (ken_burns, vignette, etc.)
 - Built with Python (MoviePy) + React
+
+---
+
+### Image Effects
+
+Each slide can apply one of several visual effects:
+
+- `depth_zoom`
+- `ken_burns`
+- `color_grade`
+- `light_leaks`
+- `film_grain`
+- `vignette`
+- `motion_overlay`
+
+Select an effect from the drop-down next to each slide on the frontend. Leave it blank for no effect.
 
 ---
 

--- a/backend/api/tests.py
+++ b/backend/api/tests.py
@@ -1,3 +1,23 @@
 from django.test import TestCase
+from django.conf import settings
+from unittest.mock import patch
+import os
 
-# Create your tests here.
+from .video_generator import generate_video
+
+
+class VideoGeneratorTests(TestCase):
+    @patch('moviepy.video.VideoClip.VideoClip.write_videofile')
+    def test_generate_video_with_image_effect(self, mock_write):
+        image_path = os.path.join(settings.BASE_DIR, 'media', 'pic 10.webp')
+        if not os.path.exists(image_path):
+            self.skipTest('Sample image not found')
+        generate_video(
+            ['hello'],
+            [image_path],
+            None,
+            'out.mp4',
+            durations=[1],
+            image_effects=['ken_burns'],
+        )
+        self.assertTrue(mock_write.called)

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -17,6 +17,7 @@ def create_slideshow(request):
         durations = request.data.getlist('duration')
         durations = [float(d) if d else 4.0 for d in durations]
         transitions = request.data.getlist('transitions')
+        image_effects = request.data.getlist('image_effects')
         images = request.FILES.getlist('images')
         raw_darkening = request.data.getlist('darkening')
         print(f"📝 darkening received: {raw_darkening}")
@@ -71,6 +72,7 @@ def create_slideshow(request):
             durations=durations,
             darkening=darkening,
             transitions=transitions,
+            image_effects=image_effects,
         )
 
         if not os.path.exists(output_path):

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -14,13 +14,23 @@ const transitionOptions = [
   'rotate',
 ];
 
+const imageEffectOptions = [
+  'depth_zoom',
+  'ken_burns',
+  'color_grade',
+  'light_leaks',
+  'film_grain',
+  'vignette',
+  'motion_overlay',
+];
+
 function App() {
   const [images, setImages] = useState([]);
   const [music, setMusic] = useState(null);
   const [duration, setDuration] = useState(4);
   const [loading, setLoading] = useState(false);
   const [slides, setSlides] = useState([
-    { text: '', position: '', darkening: '', duration: '', transition: '' },
+    { text: '', position: '', darkening: '', duration: '', transition: '', effect: '' },
   ]);
 
   const handleSlideChange = (index, field, value) => {
@@ -40,6 +50,7 @@ function App() {
       formData.append('darkening', slide.darkening);
       formData.append('duration', slide.duration); // May be blank
       formData.append('transitions', slide.transition);
+      formData.append('image_effects', slide.effect);
     });
     images.forEach(img => formData.append('images', img));
     if (music) formData.append('music', music);
@@ -115,6 +126,17 @@ function App() {
                   </option>
                 ))}
               </select>
+              <select
+                value={slide.effect}
+                onChange={(e) => handleSlideChange(i, 'effect', e.target.value)}
+              >
+                <option value="">None</option>
+                {imageEffectOptions.map((opt) => (
+                  <option key={opt} value={opt}>
+                    {opt}
+                  </option>
+                ))}
+              </select>
             </div>
           ))}
           <button
@@ -122,7 +144,7 @@ function App() {
             onClick={() =>
               setSlides([
                 ...slides,
-                { text: '', position: '', darkening: '', duration: '', transition: '' },
+                { text: '', position: '', darkening: '', duration: '', transition: '', effect: '' },
               ])
             }
           >


### PR DESCRIPTION
## Summary
- implement optional image effects in video generator
- parse `image_effects` in view and App.js
- add dropdown UI for selecting effects
- update docs on available effects
- add test for image effects

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `npm test --silent` *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848c402d6108324ba0b318ba7743710